### PR TITLE
Ignore "outDir" option in tsconfig.json

### DIFF
--- a/guess.js
+++ b/guess.js
@@ -39,5 +39,6 @@ function parseTsConfig(tsconfigPath) {
     return null;
   }
 
+  delete parsed.config.compilerOptions.outDir;
   return parsed.config.compilerOptions;
 }


### PR DESCRIPTION
espower-typescript fails if "outDir" option is used in tsconfig.json. In my pull-request, it simply ignore the "outDir" option.

#### tsconfig.json
```json
{
  "compilerOptions": {
    "target": "ES5",
    "noImplicitAny": true,
    "outDir": "build"
  }
}
```

#### Result of 'npm run test'
```
$ npm run test

> espower-typescript@3.0.0 test d:\Users\wadahiro\src\github.com\wadahiro\espower-typescript
> mocha --require ./guess test/*_test.ts

d:\Users\wadahiro\src\github.com\wadahiro\espower-typescript\node_modules\typescript-simple\index.js:134
            var text = file.text;
                           ^

TypeError: Cannot read property 'text' of undefined
    at TypeScriptSimple.toJavaScript (d:\Users\wadahiro\src\github.com\wadahiro\espower-typescript\node_modules\typescript-simple\
ndex.js:134:28)
    at TypeScriptSimple.compile (d:\Users\wadahiro\src\github.com\wadahiro\espower-typescript\node_modules\typescript-simple\index
js:52:25)
    at Object.require.extensions..ts (d:\Users\wadahiro\src\github.com\wadahiro\espower-typescript\index.js:18:22)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at d:\Users\wadahiro\src\github.com\wadahiro\espower-typescript\node_modules\mocha\lib\mocha.js:216:27
...
```