### PR TITLE
chore(deps): update internal typescript to v1.8.0

### DIFF
--- a/guess.js
+++ b/guess.js
@@ -14,7 +14,7 @@ if (packageData &&
   pattern = testDir + ((testDir.lastIndexOf('/', 0) === 0) ? '' : '/') + '**/*.ts';
 }
 
-var tsconfigPath = ts.findConfigFile(cwd);
+var tsconfigPath = ts.findConfigFile(cwd, fs.existsSync);
 var tsconfigBasepath = null;
 var compilerOptions = null;
 if (tsconfigPath) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "espower-source": "^1.1.0",
     "minimatch": "^3.0.0",
-    "typescript": "1.8.0-dev.20151106",
+    "typescript": "~1.8.0",
     "typescript-simple": "^4.0.0"
   }
 }


### PR DESCRIPTION
This `typescript` is used only for finding tsconfig.json, not for compiling files.