### PR TITLE
fix(index): support outDir option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs');
+var path = require('path');
 
 var espowerSource = require('espower-source');
 var minimatch = require('minimatch');
@@ -8,13 +9,14 @@ var ts = require('typescript');
 var TypeScriptSimple = require('typescript-simple').TypeScriptSimple;
 
 function espowerTypeScript(options) {
+  var cwd = options.cwd || process.cwd();
   var separator = (options.pattern.lastIndexOf('/', 0) === 0) ? '' : '/';
-  var pattern = options.cwd + separator + options.pattern;
-  var compilerOptions = convertCompilerOptions(options.compilerOptions, options.basepath);
+  var pattern = cwd + separator + options.pattern;
+  var compilerOptions = convertCompilerOptions(options.compilerOptions, options.basepath || cwd);
   var tss = new TypeScriptSimple(compilerOptions, false);
 
   function loadTypeScript(localModule, filepath) {
-    var result = tss.compile(fs.readFileSync(filepath, 'utf-8'));
+    var result = tss.compile(fs.readFileSync(filepath, 'utf-8'), path.relative(cwd, filepath));
     if (minimatch(filepath, pattern)) {
       result = espowerSource(result, filepath, options);
     }
@@ -30,7 +32,6 @@ function convertCompilerOptions(compilerOptions, basepath) {
     return null;
   }
 
-  var basepath = basepath || process.cwd();
   var converted = ts.convertCompilerOptionsFromJson(compilerOptions, basepath);
   if (converted.errors && converted.errors.length > 0) {
     var msg = converted.errors.map(function(e) {return e.messageText}).join(', ');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "power-assert instrumentor for TypeScript",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --require './guess' test/*_test.ts"
+    "test:outdir": "cd test/test-outdir && mocha --require ../../guess test/*_test.ts",
+    "test": "mocha --require './guess' test/*_test.ts && npm run test:outdir"
   },
   "repository": {
     "type": "git",

--- a/test/test-outdir/package.json
+++ b/test/test-outdir/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-outdir",
+  "version": "1.0.0",
+  "description": "This is a dummy file. See ../../package.json",
+  "devDependencies": {
+  },
+  "dependencies": {
+  }
+}

--- a/test/test-outdir/test/to_be_instrumented_test.ts
+++ b/test/test-outdir/test/to_be_instrumented_test.ts
@@ -1,0 +1,29 @@
+'use strict';
+
+import assert = require('power-assert')
+import expect = require('expect.js')
+import MyComponent from '../lib/mycomponent.tsx';
+
+describe('test for outDir option', function() {
+  beforeEach(function() {
+    this.expectPowerAssertMessage = (body: () => void, expectedLines: string) => {
+      try {
+        body();
+        expect().fail('AssertionError should be thrown');
+      } catch(e) {
+        expect(e.message.split('\n').slice(2, -1).join('\n')).to.eql(expectedLines);
+      }
+    }
+  });
+
+  it('equal with Literal and Identifier: assert.equal(1, minusOne)', function() {
+    let minusOne: number = -1;
+    let expected: string =
+`  assert.equal(1, minusOne)
+                  |        
+                  -1       `;
+    this.expectPowerAssertMessage(() => {
+      assert.equal(1, minusOne);
+    }, expected);
+  });
+});

--- a/test/test-outdir/tsconfig.json
+++ b/test/test-outdir/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "outDir": "build",
+    "module": "commonjs",
+    "target": "ES5",
+    "noImplicitAny": true,
+    "jsx": "react"
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
When `outDir` option in `tsconfig.json` was enabled and a relative path to a parent directory was used for imported module like `import foo from '../foo', it threw an unexpected exception.

fix #14.