### PR TITLE
Transpile `.js` files as well if `allowJs:true` exists in tsconfig.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-test/**/*.js
+/node_modules
+test/test-outdir/**/*.js

--- a/guess.js
+++ b/guess.js
@@ -2,18 +2,6 @@ var fs = require('fs');
 var path = require('path');
 
 var ts = require('typescript');
-
-var pattern = 'test/**/*.ts';
-var cwd = process.cwd();
-var packageData = require(path.join(cwd, 'package.json'));
-
-if (packageData &&
-    typeof packageData.directories === 'object' &&
-    typeof packageData.directories.test === 'string') {
-  var testDir = packageData.directories.test;
-  pattern = testDir + ((testDir.lastIndexOf('/', 0) === 0) ? '' : '/') + '**/*.ts';
-}
-
 var tsconfigPath = ts.findConfigFile(cwd, fs.existsSync);
 var tsconfigBasepath = null;
 var compilerOptions = null;
@@ -21,6 +9,19 @@ if (tsconfigPath) {
   compilerOptions = parseTsConfig(tsconfigPath);
   tsconfigBasepath = path.dirname(tsconfigPath);
 }
+var allowJs = (compilerOptions && compilerOptions.allowJs);
+
+var cwd = process.cwd();
+var packageData = require(path.join(cwd, 'package.json'));
+var testDir;
+if (packageData &&
+    typeof packageData.directories === 'object' &&
+    typeof packageData.directories.test === 'string') {
+    testDir = packageData.directories.test;
+} else {
+    testDir = 'test';
+}
+var pattern = testDir + ((testDir.lastIndexOf('/', 0) === 0) ? '' : '/') + (allowJs ? '**/*.{js,ts}' : '**/*.ts');
 
 require('./index')({
     cwd: cwd,

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function espowerTypeScript(options) {
   var pattern = cwd + separator + options.pattern;
   var compilerOptions = convertCompilerOptions(options.compilerOptions, options.basepath || cwd);
   var tss = new TypeScriptSimple(compilerOptions, false);
+  var allowJs = (compilerOptions && compilerOptions.allowJs);
 
   function loadTypeScript(localModule, filepath) {
     var result = tss.compile(fs.readFileSync(filepath, 'utf-8'), path.relative(cwd, filepath));
@@ -25,6 +26,9 @@ function espowerTypeScript(options) {
 
   require.extensions['.ts'] = loadTypeScript;
   require.extensions['.tsx'] = loadTypeScript;
+  if (allowJs) {
+    require.extensions['.js'] = loadTypeScript;
+  }
 }
 
 function convertCompilerOptions(compilerOptions, basepath) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "index.js",
   "scripts": {
     "demo": "mocha --require './guess' test/demo.ts",
-    "test": "mocha --require './guess' test/*_test.ts && npm run test:outdir",
+    "test": "mocha --require './guess' test/*_test.ts && npm run test:outdir && npm run test:allowJs",
+    "test:allowJs": "cd test/test-allow-js && mocha --require ../../guess test/*_test.js",
     "test:outdir": "cd test/test-outdir && mocha --require ../../guess test/*_test.ts"
   },
   "dependencies": {

--- a/test/test-allow-js/package.json
+++ b/test/test-allow-js/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-allow-js",
+  "version": "1.0.0",
+  "description": "This is a dummy file. See ../../package.json",
+  "devDependencies": {
+  },
+  "dependencies": {
+  }
+}

--- a/test/test-allow-js/test/to_be_instrumented_test.js
+++ b/test/test-allow-js/test/to_be_instrumented_test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+import assert = require('assert')
+import expect = require('expect.js')
+import MyComponent from '../lib/mycomponent.tsx';
+
+describe('test for allowJs option', function() {
+  beforeEach(function() {
+    this.expectPowerAssertMessage = (body: () => void, expectedLines: string) => {
+      try {
+        body();
+        expect().fail('AssertionError should be thrown');
+      } catch(e) {
+        expect(e.message.split('\n').slice(2, -1).join('\n')).to.eql(expectedLines);
+      }
+    }
+  });
+
+  it('equal with Literal and Identifier: assert.equal(1, minusOne)', function() {
+    let minusOne: number = -1;
+    let expected: string =
+`  assert.equal(1, minusOne)
+                  |        
+                  -1       `;
+    this.expectPowerAssertMessage(() => {
+      assert.equal(1, minusOne);
+    }, expected);
+  });
+});

--- a/test/test-allow-js/tsconfig.json
+++ b/test/test-allow-js/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "outDir": "build",
+    "module": "commonjs",
+    "target": "ES5",
+    "noImplicitAny": true,
+    "jsx": "react"
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This PR adds `.js` files to transpile target as well if and only if `allowJs:true` exists in tsconfig.json

@teppeis, I have two questions. 
1. Is this PR matches to espower-typescript's philosophy? (If not, please feel free to reject this PR)
2. `TypeError: Cannot read property 'text' of undefined` has occurred. Is this error related to typescript-simple?