### PR TITLE
fix: espower throw error Attempted to transform AST twice when use allowJs true, and there has  js and ts files in test directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function espowerTsRegister(ext, options) {
 
   const originalExtension = require.extensions[ext];
   require.extensions[ext] = (module, filepath) => {
-    if (!minimatch(filepath, pattern)) {
+    if (!minimatch(filepath, pattern) || ext === '.js') {
       return originalExtension(module, filepath);
     }
     const originalCompile = module._compile;


### PR DESCRIPTION
bugfix: 
bug performance: when use allowJs: true in tsconfig.json, and has js and ts file in test directory, it will throw error : espower Attempted to transform AST twice.

cause reason: as for js file,  espower-loader will call espower-source instrument target ast as output, and then call localModule._compile to handle output， see https://github.com/power-assert-js/espower-loader/blob/master/index.js#L42 and https://github.com/power-assert-js/espower-loader/blob/master/index.js#L45。while espower-typescript add _compile function to js file which is also call espower-source to cook code and instrument ast。

fix: so we can exclude js file when add _compile funciton to module, leave js file handling by espower-loader。